### PR TITLE
limit text output in html files generated from notebooks

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -12,3 +12,9 @@
        overflow: visible !important;
     }
  }
+
+/* Limit visible text output to about 30 lines and show scrollbar */
+.nboutput .output_area div > pre {
+        overflow-y: scroll !important;
+        max-height: 30em;
+}


### PR DESCRIPTION
Addresses the problem of the very long text output of some notebook cells. Seems to work well, checked some of the doc files with chrome. 
Not sure if there will be problems for more complicated output that mixes text and plots, I did not see any.