### PR TITLE
More control over jupyter execution, enable xvfb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
     # Build docs only
     - os: linux
       dist: bionic
+      services:
+        - xvfb
       sudo: true
       language: python
       python: "3.6"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -208,27 +208,6 @@ texinfo_documents = [(
 #            properties. Within each, sorted alphabetically.
 autodoc_member_order = "groupwise"
 
-# Copy jupyter notebooks and test data to tutorial folder
-test_data_in_dir = Path(current_file_dir).parent / "examples" / "TestData"
-test_data_out_dir = Path(current_file_dir) / "TestData"
-if test_data_out_dir.exists():
-    shutil.rmtree(test_data_out_dir)
-shutil.copytree(test_data_in_dir, test_data_out_dir)
-example_dirs = ["Basic", "Advanced"]
-for example_dir in example_dirs:
-    in_dir = Path(current_file_dir).parent / "examples" / "Python" / example_dir
-    out_dir = Path(current_file_dir) / "tutorial" / example_dir
-    # remove all existing jupyter notebooks
-    for nb_out_path in out_dir.glob("*.ipynb"):
-        nb_out_path.unlink()
-    shutil.copy(
-        in_dir.parent / "open3d_tutorial.py",
-        out_dir.parent / "open3d_tutorial.py",
-    )
-    for nb_in_path in in_dir.glob("*.ipynb"):
-        nb_out_path = out_dir / nb_in_path.name
-        shutil.copy(nb_in_path, nb_out_path)
-
 
 def is_enum_class(func, func_name):
 

--- a/examples/Python/jupyter_run_all.py
+++ b/examples/Python/jupyter_run_all.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     nb_paths = sorted((file_dir / "Basic").glob("*.ipynb"))
     nb_paths += sorted((file_dir / "Advanced").glob("*.ipynb"))
     for nb_path in nb_paths:
-        print(f"Execute {nb_path.name}")
+        print(f"[Executing notebook {nb_path.name}]")
 
         with open(nb_path) as f:
             nb = nbformat.read(f, as_version=4)

--- a/examples/Python/open3d_tutorial.py
+++ b/examples/Python/open3d_tutorial.py
@@ -36,7 +36,7 @@ def jupyter_draw_geometries(
         height=height,
         left=left,
         top=top,
-        visible=interactive,
+        visible=True,  # If false, capture_screen_float_buffer() won't work.
     )
     vis.get_render_option().point_show_normal = point_show_normal
     vis.get_render_option().mesh_show_wireframe = mesh_show_wireframe

--- a/util/scripts/make-documentation.sh
+++ b/util/scripts/make-documentation.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Documentation build scripts for CI
 #
+# To build documentation locally, ignore the xvfb-run and arguments.
+#
 # Prerequisites:
 # pip install sphinx sphinx-autobuild
 # sudo apt-get -y install doxygen
@@ -9,5 +11,5 @@ set -e
 curr_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 pushd ${curr_dir}/../../docs
-python make_docs.py --sphinx --doxyge
+xvfb-run --server-args="-screen 0 1024x768x24" python make_docs.py --clean_notebooks --execute_notebooks=auto --sphinx --doxyge
 popd


### PR DESCRIPTION
`nbsphinx` always builds Jupyter notebooks if there are no outputs, and the build runs in parallel. This setup sometimes results in infinite hung (sees to be related to multiprocessing and pipe). We can execute the notebooks first and then call sphinx build. This way, we have more control over how the notebooks are executed.

Example commands:
```
python make_docs.py --clean_notebooks --execute_notebooks=auto --sphinx --doxygen
```

This PR also tries to enable `xvfb` in Travis. In my local machine, `xvfb` runs, but always gives black image while capturing screen buffer. If this is also the case for Travis, then we can only rely on Travis to test whether the notebooks can run, but we cannot determine the correctness of the outputs. Additionally, our docs server may be affected due to the `xvfb` setup.